### PR TITLE
fix: always initiate boarding sequence

### DIFF
--- a/simulation/README.md
+++ b/simulation/README.md
@@ -5,7 +5,7 @@ CONDITION: elevator is moving in direction up
 0. Elevator reaches the floor
     What this means is that we eliminate any internal calls and any external calls
 
-    DOOR OPEN --> triggers ALIGHT if alighting, triggers BOARD if boarding, triggers DOOR CLOSE
+    DOOR OPEN --> triggers ALIGHT if alighting, triggers BOARD 
 
 1. Check if there is anyone alighting
 
@@ -30,7 +30,7 @@ CONDITION: elevator is moving in direction up
 
 11. check if there are any calls below this floor as well (this includes anyone who wants to board on this floor)
 
-    DOOR OPEN --> trigger BOARD if boarding else DOOR CLOSE
+    DOOR OPEN --> triggers ALIGHT if alighting, triggers BOARD 
 
 12. if yes, change direction
     This then means we eliminate the external call that is to go down

--- a/simulation/classes/controller.py
+++ b/simulation/classes/controller.py
@@ -127,6 +127,10 @@ class EqualController(Controller):
                 return min(farthest_up)
 
         print(move_direction)
+        print("int call:", self.int_call)
+        print("ext up call:", [e_call.up_call for e_call in self.ext_call])
+        print("ext down call:", [e_call.down_call for e_call in self.ext_call])
+        
         raise Exception("No remaining calls in selected direction")
 
 
@@ -144,9 +148,9 @@ class EqualController(Controller):
         Returns the next direction
         """
         # Any internal calls left?
-        print("int call:", self.int_call)
-        print("ext up call:", [e_call.up_call for e_call in self.ext_call])
-        print("ext down call:", [e_call.down_call for e_call in self.ext_call])
+        # print("int call:", self.int_call)
+        # print("ext up call:", [e_call.up_call for e_call in self.ext_call])
+        # print("ext down call:", [e_call.down_call for e_call in self.ext_call])
         if self.int_call:
             # if yes continue same direction
             return move_direction

--- a/simulation/classes/moveEvents.py
+++ b/simulation/classes/moveEvents.py
@@ -97,19 +97,9 @@ class DoorOpenEvent(MoveEvent):
             # trigger an alight event
             yield passE.AlightEvent(self.time, self.floor, self.building)
 
-        door_close = True
-        if self.building.check_boarding(self.floor, self.elevator.direction):
-            door_close = False
-            yield passE.BoardEvent(self.time + self.elevator.open_door_time, self.floor, self.building)
+        # always try to board even if there is no one this is so we will check
+        yield passE.BoardEvent(self.time + self.elevator.open_door_time, self.floor, self.building)
 
-        # regardless, we then need to trigger a 
-        # DoorCloseEvent and see what the next steps are
-        if door_close:
-            yield DoorCloseEvent(
-                        self.time + self.elevator.open_door_time,
-                        self.floor,
-                        self.building
-                    )
 
 
 class DoorCloseEvent(MoveEvent):

--- a/simulation/main.py
+++ b/simulation/main.py
@@ -6,4 +6,4 @@ random.seed(1)
 np.random.seed(1)
 sim = Simulation()
 
-sim.simulate(200)
+sim.simulate(4590)

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -47,22 +47,22 @@ class Simulation:
 
         self.initialize_building()
 
-        rate_matrix = [
-                [0, 100, 100, 100],
-                [100, 0, 100, 100],
-                [100, 100, 0, 100],
-                [100, 100, 100, 0]
-            ]
+        uniform_rate = 20
+        rate_matrix = [[uniform_rate] * self.num_floors for _ in range(self.num_floors)]
 
         self.initialize_arrivals(rate_matrix)
-        print(self.building.elevator.direction)
+        # print(self.building.elevator.direction)
+        count = 0
         while self.event_queue[0][0] < max_time:
 
             event_time, event = heappop(self.event_queue)
 
             # if self.elevator.direction == Move.IDLE:
             print(event)
-            print(self.elevator.direction)
+            # print(self.elevator.get_num_passengers())
+            if self.elevator.direction == Move.IDLE:
+                count += 1
+            # print(self.elevator.direction)
             for new_event in event.update():
 
             # TODO NEED TO REMOVE MoveIdleEvent, if the new Event is a UpdateEvent
@@ -71,3 +71,6 @@ class Simulation:
                     new_queue = [(t, e) for t, e in self.event_queue if not isinstance(e, moveE.MoveIdleEvent)]
                     self.event_queue = new_queue
                 heappush(self.event_queue, (new_event.time, new_event))
+
+        print("NUMBER OF CYCLES")
+        print(count)


### PR DESCRIPTION
so the lift was at floor 2
then no one boarding, so it doesn't trigger the boarding sequence
then someone spawns at floor 2 before the door closes (the person is going up)
then the boarding sequence is not triggered
BUT the lift wants to go up since it recognizes a call at floor 2 asking it to go up
so it tries to go up, then reaches 3, and realises, there are no more calls

fix: always call the boarding sequence